### PR TITLE
Fix CFM-05 issue from the audit

### DIFF
--- a/client.go
+++ b/client.go
@@ -159,19 +159,22 @@ func (cc *ClientConn) listenForConnectivityChange() {
 // listenForRead listens for the connectivty state to be ready and enables the
 // read handler
 func (cc *ClientConn) listenForRead() {
+	var done chan struct{}
 	for {
 		notifyChan := cc.csMgr.getNotifyChan()
 		<-notifyChan
 
 		s := cc.csMgr.state
 
-		var done chan struct{}
 		if s == connectivity.Ready {
-			done := make(chan struct{})
+			if done == nil {
+				done = make(chan struct{})
+			}
 			go cc.handleRead(done)
 		} else {
 			if done != nil {
 				close(done)
+				done = nil
 			}
 		}
 	}


### PR DESCRIPTION
[sc-21195]

The audit showed that there is an unreachable if branch in the
listenForRead() method: In cases where s == connectivity.Ready is false
and the else block is executed, the "if done != nil" block is never
actually executed. This is because the "done" variable is always nil.

Note that this change will end up closing _all_ goroutines that are running
the handleRead() method. This makes sense, espcially if the connection
to the server is severed.