### PR TITLE
Fix ping handler on WS server

### DIFF
--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -107,7 +107,7 @@ func (s *WebsocketServer) pingHandler(message string) error {
 		return err
 	}
 
-	err := s.conn.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(time.Second))
+	err := s.conn.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(s.writeTimeout))
 	if err == websocket.ErrCloseSent {
 		return nil
 	} else if e, ok := err.(net.Error); ok && e.Temporary() {

--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"errors"
 	"net"
 	"sync"
 	"time"
@@ -109,11 +110,12 @@ func (s *WebsocketServer) pingHandler(message string) error {
 	}
 
 	err := s.conn.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(s.writeTimeout))
-	if err == websocket.ErrCloseSent {
+	if errors.Is(err, websocket.ErrCloseSent) {
 		return nil
-	} else if e, ok := err.(net.Error); ok && e.Temporary() {
+	} else if e, ok := err.(net.Error); ok && e.Temporary() { // nolint (we can't really use errors.As() since net.Error is an interface.)
 		return nil
 	}
+
 	return err
 }
 


### PR DESCRIPTION
[sc-21202]

Fix the ping handler on the websocket server to write a control message explicitly after updating the read deadline on the connection.

This was tested by running the example client and server in the examples/simple directory and adding logs in the ping and pong handlers of the server and client types respectively.

Aside: would be useful to incorporate zap or a similar logging library so that we can have structured logging in wsrpc.