### PR TITLE
Close existing connections for certs removed when updating certs

### DIFF
--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -18,7 +18,7 @@ type WebsocketServer struct {
 	// Underlying communication channel
 	conn *websocket.Conn
 
-	// The current start of the server transport
+	// The current state of the server transport
 	state transportState
 
 	// Callback function called when the transport is closed


### PR DESCRIPTION
when we update the list of allowable certs, we need to also check
for existing connections using any removed certs