### PR TITLE
Configure the call timeout with the context

### DIFF
--- a/client.go
+++ b/client.go
@@ -320,13 +320,13 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{
 		if err != nil {
 			return err
 		}
-	case <-time.After(2 * time.Second): // TODO - Make this configurable
+	case <-ctx.Done():
 		// Remove the call since we have timeout
 		cc.mu.Lock()
 		cc.removeMethodCall(callID)
 		cc.mu.Unlock()
 
-		return errors.New("call timeout")
+		return fmt.Errorf("call timeout: %w", ctx.Err())
 	}
 
 	return nil

--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -66,12 +66,19 @@ func main() {
 // pingContinuously sends a Ping RPC call to the server every 5 seconds
 func pingContinuously(client pb.PingClient) {
 	for {
-		res, err := client.Ping(context.Background(), &pb.PingRequest{Body: "ping"})
-		if err != nil {
-			log.Printf("[RPC CALL] Some error ocurred pinging: %v", err)
-		} else {
-			log.Printf("[RPC CALL] CALL: Ping -> %s", res.GetBody())
-		}
+		func() {
+			// Set a deadline
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			// Call the server
+			res, err := client.Ping(ctx, &pb.PingRequest{Body: "ping"})
+			if err != nil {
+				log.Printf("[CALL] Some error ocurred pinging: %v", err)
+			} else {
+				log.Printf("[CALL] Ping -> %s", res.GetBody())
+			}
+		}()
 
 		time.Sleep(5 * time.Second)
 	}
@@ -85,7 +92,7 @@ type gnipClient struct{}
 func (c *gnipClient) Gnip(ctx context.Context, req *pb.GnipRequest) (*pb.GnipResponse, error) {
 	resBody := "gnop"
 
-	log.Printf("[RPC SERVICE HANDLER] %s -> %s", req.Body, resBody)
+	log.Printf("[HANDLER] %s -> %s", req.Body, resBody)
 
 	return &pb.GnipResponse{
 		Body: resBody,

--- a/server.go
+++ b/server.go
@@ -5,11 +5,11 @@ import (
 	"crypto/ed25519"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -304,13 +304,13 @@ func (s *Server) Invoke(ctx context.Context, method string, args interface{}, re
 		if err != nil {
 			return err
 		}
-	case <-time.After(2 * time.Second): // TODO - Make this configurable
+	case <-ctx.Done():
 		// Remove the call since we have timeout
 		s.mu.Lock()
 		s.removeMethodCall(callID)
 		s.mu.Unlock()
 
-		return errors.New("call timeout")
+		return fmt.Errorf("call timeout: %w", ctx.Err())
 	}
 
 	return nil


### PR DESCRIPTION
We had previously hardcoded a 2s timeout value for a client/server to wait for an RPC response. This has been changed to respect the context that is already provided, and will timeout when the context is cancelled/expired.

By default we there is no deadline for a request to complete unless explicitly set in the context.