### PR TITLE
Close the websocket connection when a write error occurs

### DIFF
--- a/client.go
+++ b/client.go
@@ -473,6 +473,8 @@ func (ac *addrConn) resetTransport() {
 		// Block until the created transport is down. When this happens, we
 		// attempt to reconnect by starting again from the top
 		<-reconnect.Done()
+
+		log.Println("[wsrpc] Reconnecting to server...")
 	}
 }
 

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -3,6 +3,7 @@ package wsrpc
 import (
 	"crypto/ed25519"
 	"log"
+	"time"
 
 	"github.com/smartcontractkit/wsrpc/credentials"
 	"github.com/smartcontractkit/wsrpc/internal/backoff"
@@ -62,6 +63,14 @@ func WithTransportCreds(privKey ed25519.PrivateKey, serverPubKey ed25519.PublicK
 func WithBlock() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.block = true
+	})
+}
+
+// WithWriteTimeout returns a DialOption which sets the write timeout for a
+// message to be sent on the wire.
+func WithWriteTimeout(d time.Duration) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.copts.WriteTimeout = d
 	})
 }
 


### PR DESCRIPTION
This was causing the server to not receive a close error so it would not
clear the clients public key from it's list of connected clients. This in turn
would cause the client to be unable to connect again as the server believes
that the client is already connected