### PR TITLE
Fixes an issue where clients were unable to reconnect

### DIFF
--- a/client.go
+++ b/client.go
@@ -453,7 +453,8 @@ func (ac *addrConn) resetTransport() {
 			ac.updateConnectivityState(connectivity.TransientFailure)
 			ac.mu.Unlock()
 
-			// Backoff.
+			// Reconnection backoff time
+			log.Println("[wsrpc] attempting reconnection in", backoffFor)
 			timer := time.NewTimer(backoffFor)
 
 			select {
@@ -482,6 +483,8 @@ func (ac *addrConn) resetTransport() {
 		ac.updateConnectivityState(connectivity.Ready)
 
 		ac.mu.Unlock()
+
+		log.Println("[wsrpc] Connected to", ac.addr)
 
 		// Block until the created transport is down. When this happens, we
 		// attempt to reconnect by starting again from the top

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -84,3 +84,9 @@ type ServerTransport interface {
 func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func()) (ServerTransport, error) {
 	return newWebsocketServer(c, config, onClose), nil
 }
+
+func handlePong(conn *websocket.Conn) func(string) error {
+	return func(msg string) error {
+		return conn.SetReadDeadline(time.Now().Add(pongWait))
+	}
+}


### PR DESCRIPTION
When dealing with clients with poor networks (high latency or unstable connectivity) the server would occassionally not drop the connection, leading to clients being unable to reconnect because the server only allows a single connection per Public Key.

This change makes the server send periodic pings to the clients, and will drop the connection if no response is received. This allows the client to re-obtain a connection when the network comes back up for them again.

The ping handler has also been removed in favour of the default implementation which was performing the same function but with a lower ping read timeout.