### PR TITLE
Fix potential deadlock in client & server writes 

### DIFF
--- a/client.go
+++ b/client.go
@@ -280,7 +280,7 @@ func (cc *ClientConn) handleMessageRequest(r *message.Request) {
 		cc.conn.mu.RUnlock()
 		cc.mu.RUnlock()
 
-		if err := tr.Write(replyMsg); err != nil {
+		if err := tr.Write(ctx, replyMsg); err != nil {
 			cc.dopts.logger.Errorf("error writing to transport: %s", err)
 		}
 	}
@@ -376,7 +376,7 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{
 	cc.conn.mu.RUnlock()
 	cc.mu.RUnlock()
 
-	if err := tr.Write(reqB); err != nil {
+	if err := tr.Write(ctx, reqB); err != nil {
 		return err
 	}
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -73,7 +73,7 @@ type ServerTransport interface {
 	Read() <-chan []byte
 
 	// Write sends a message to the stream.
-	Write(msg []byte) error
+	Write(ctx context.Context, msg []byte) error
 
 	// Close tears down the transport. Once it is called, the transport
 	// should not be accessed any more.

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -36,7 +36,7 @@ type ClientTransport interface {
 	Read() <-chan []byte
 
 	// Write sends a message to the stream.
-	Write(msg []byte) error
+	Write(ctx context.Context, msg []byte) error
 
 	// Close tears down this transport. Once it returns, the transport
 	// should not be accessed any more.

--- a/server.go
+++ b/server.go
@@ -177,7 +177,7 @@ func (s *Server) wshandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // sendMsg writes the message to the connection which matches the public key.
-func (s *Server) sendMsg(pub [32]byte, msg []byte) error {
+func (s *Server) sendMsg(ctx context.Context, pub [32]byte, msg []byte) error {
 	// Find the transport matching the public key
 	s.mu.RLock()
 	tr, err := s.connMgr.getTransport(pub)
@@ -186,7 +186,7 @@ func (s *Server) sendMsg(pub [32]byte, msg []byte) error {
 		return err
 	}
 
-	return tr.Write(msg)
+	return tr.Write(ctx, msg)
 }
 
 // handleRead listens to the transport read channel and passes the message to the
@@ -248,7 +248,7 @@ func (s *Server) handleMessageRequest(pubKey credentials.StaticSizedPublicKey, r
 			return
 		}
 
-		if err := s.sendMsg(pubKey, replyMsg); err != nil {
+		if err := s.sendMsg(ctx, pubKey, replyMsg); err != nil {
 			log.Printf("error sending message: %s", err)
 		}
 	}
@@ -314,7 +314,7 @@ func (s *Server) Invoke(ctx context.Context, method string, args interface{}, re
 	}
 	pubKey := p.PublicKey
 
-	if err = s.sendMsg(pubKey, req); err != nil {
+	if err = s.sendMsg(ctx, pubKey, req); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This fixes a potential deadlock when writing to the websocket in both the client and the server.

To summarize the issue, let's focus on the client side of things. Requests are handled in `Invoke` and call out to the client transport [here](https://github.com/smartcontractkit/wsrpc/blob/b5d02d0734935fdcdd8e2b5423087e8dcce4fbf6/client.go#L379), which runs [this code](https://github.com/smartcontractkit/wsrpc/blob/b5d02d0734935fdcdd8e2b5423087e8dcce4fbf6/internal/transport/websocket_client.go#L81) to write a message to the websocket connection. This channel is read by the `writePump` go routine [here](https://github.com/smartcontractkit/wsrpc/blob/b5d02d0734935fdcdd8e2b5423087e8dcce4fbf6/internal/transport/websocket_client.go#L135) which reads the message off the channel and writes it to the raw websocket. 

A deadlock can occur though if there are any pending `Invoke` calls while the `writePump` exits. Because a new client transport gets created when the [connection is reset](https://github.com/smartcontractkit/wsrpc/blob/main/client.go#L505), there's nothing to read off the original `write` channel and `Invoke` gets stuck. 

The fix here is to use a select statement in the transport `Write` and return with an error on the same conditions the `writePump` uses to exit. A context has also been added so we can return early if the context expires. 