### PR TITLE
bug/2263: fixing data race with serve wait group

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -82,8 +82,8 @@ type ServerTransport interface {
 
 // NewServerTransport creates a ServerTransport with conn or non-nil error
 // if it fails.
-func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func()) (ServerTransport, error) {
-	return newWebsocketServer(c, config, onClose), nil
+func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func(), onStart func()) (ServerTransport, error) {
+	return newWebsocketServer(c, config, onClose, onStart), nil
 }
 
 func handlePong(conn *websocket.Conn) func(string) error {

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -83,6 +83,7 @@ type ServerTransport interface {
 // NewServerTransport creates a ServerTransport with conn or non-nil error
 // if it fails.
 func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func(), onStart func()) (ServerTransport, error) {
+	onStart()
 	return newWebsocketServer(c, config, onClose, onStart), nil
 }
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -82,9 +82,8 @@ type ServerTransport interface {
 
 // NewServerTransport creates a ServerTransport with conn or non-nil error
 // if it fails.
-func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func(), onStart func()) (ServerTransport, error) {
-	onStart()
-	return newWebsocketServer(c, config, onClose, onStart), nil
+func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func()) (ServerTransport, error) {
+	return newWebsocketServer(c, config, onClose), nil
 }
 
 func handlePong(conn *websocket.Conn) func(string) error {

--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -22,6 +22,9 @@ type WebsocketServer struct {
 	// The current state of the server transport
 	state transportState
 
+	// Callback function called when the transport is opened
+	onStart func()
+
 	// Callback function called when the transport is closed
 	onClose func()
 
@@ -36,7 +39,7 @@ type WebsocketServer struct {
 }
 
 // newWebsocketServer server upgrades an HTTP connection to a websocket connection.
-func newWebsocketServer(c *websocket.Conn, config *ServerConfig, onClose func()) *WebsocketServer {
+func newWebsocketServer(c *websocket.Conn, config *ServerConfig, onClose func(), onStart func()) *WebsocketServer {
 	writeTimeout := defaultWriteTimeout
 	if config.WriteTimeout != 0 {
 		writeTimeout = config.WriteTimeout
@@ -46,6 +49,7 @@ func newWebsocketServer(c *websocket.Conn, config *ServerConfig, onClose func())
 		writeTimeout: writeTimeout,
 		conn:         c,
 		onClose:      onClose,
+		onStart:      onStart,
 		write:        make(chan []byte),
 		read:         make(chan []byte),
 		done:         make(chan struct{}),
@@ -103,6 +107,7 @@ func (s *WebsocketServer) start() {
 		s.Close()
 		s.onClose()
 	}()
+	s.onStart()
 
 	// Set up reader
 	go s.readPump()

--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -107,7 +107,7 @@ func (s *WebsocketServer) start() {
 		s.Close()
 		s.onClose()
 	}()
-	s.onStart()
+	//s.onStart()
 
 	// Set up reader
 	go s.readPump()

--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -39,7 +39,7 @@ type WebsocketServer struct {
 }
 
 // newWebsocketServer server upgrades an HTTP connection to a websocket connection.
-func newWebsocketServer(c *websocket.Conn, config *ServerConfig, onClose func(), onStart func()) *WebsocketServer {
+func newWebsocketServer(c *websocket.Conn, config *ServerConfig, onClose func()) *WebsocketServer {
 	writeTimeout := defaultWriteTimeout
 	if config.WriteTimeout != 0 {
 		writeTimeout = config.WriteTimeout
@@ -49,7 +49,6 @@ func newWebsocketServer(c *websocket.Conn, config *ServerConfig, onClose func(),
 		writeTimeout: writeTimeout,
 		conn:         c,
 		onClose:      onClose,
-		onStart:      onStart,
 		write:        make(chan []byte),
 		read:         make(chan []byte),
 		done:         make(chan struct{}),

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -160,9 +161,19 @@ func (s *Server) wshandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	onStart := func() {
-		s.mu.RLock()
-		defer s.mu.RUnlock()
+		// s.mu.RLock()
+		// defer s.mu.RUnlock()
 		s.serveWG.Add(1)
+		time.Sleep(150 * time.Millisecond)
+	}
+
+
+	// Register the transport against the public key
+	s.mu.RLock()
+
+	if nil == s.connMgr {
+		s.mu.RUnlock()
+		return
 	}
 
 	// Initialize the transport
@@ -170,9 +181,6 @@ func (s *Server) wshandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-
-	// Register the transport against the public key
-	s.mu.RLock()
 	err = s.connMgr.registerConnection(pubKey, tr)
 	s.mu.RUnlock()
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -164,8 +164,8 @@ func (s *Server) wshandler(w http.ResponseWriter, r *http.Request) {
 		s.mu.RUnlock()
 		return
 	}
-
 	s.serveWG.Add(1)
+
 	// Initialize the transport
 	tr, err := transport.NewServerTransport(conn, config, onClose)
 	if err != nil {
@@ -495,9 +495,6 @@ func newConnectionsManager() *connectionsManager {
 
 // getTransport fetches the transport which matches the public key.
 func (cm *connectionsManager) getTransport(key credentials.StaticSizedPublicKey) (transport.ServerTransport, error) {
-	if cm == nil {
-		return nil, ErrServerShuttingDown
-	}
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 
@@ -511,10 +508,6 @@ func (cm *connectionsManager) getTransport(key credentials.StaticSizedPublicKey)
 
 // registerConnection registers a new transport mapped to a public key.
 func (cm *connectionsManager) registerConnection(key credentials.StaticSizedPublicKey, value transport.ServerTransport) (err error) {
-	if cm == nil {
-		err = ErrServerShuttingDown
-		return
-	}
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.conns[key] = value


### PR DESCRIPTION
You can tickle the data race in the previous code by adding a sleep on line 167.