### PR TITLE
bug/2263-logical-races: client cleanup logic is now sync

### DIFF
--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -31,7 +31,7 @@ func main() {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	conn, err := wsrpc.DialWithContext(ctx, "127.0.0.1:1338",
+	conn, err := wsrpc.DialWithContext(ctx, cancel, "127.0.0.1:1338",
 		wsrpc.WithTransportCreds(privKey, serverPubKey),
 		wsrpc.WithBlock(),
 	)

--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -31,7 +31,7 @@ func main() {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	conn, err := wsrpc.DialWithContext(ctx, cancel, "127.0.0.1:1338",
+	conn, err := wsrpc.DialWithContext(ctx, "127.0.0.1:1338",
 		wsrpc.WithTransportCreds(privKey, serverPubKey),
 		wsrpc.WithBlock(),
 	)

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -48,8 +48,8 @@ type ClientTransport interface {
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(ctx context.Context, lggr logger.Logger, addr string, opts ConnectOptions, onClose func()) (ClientTransport, error) {
-	return newWebsocketClient(ctx, lggr, addr, opts, onClose)
+func NewClientTransport(ctx context.Context, lggr logger.Logger, addr string, opts ConnectOptions, afterWritePump func()) (ClientTransport, error) {
+	return newWebsocketClient(ctx, lggr, addr, opts, afterWritePump)
 }
 
 // state of transport.
@@ -85,8 +85,8 @@ type ServerTransport interface {
 
 // NewServerTransport creates a ServerTransport with conn or non-nil error
 // if it fails.
-func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func()) ServerTransport {
-	return newWebsocketServer(c, config, onClose)
+func NewServerTransport(c *websocket.Conn, config *ServerConfig, afterWritePump func()) ServerTransport {
+	return newWebsocketServer(c, config, afterWritePump)
 }
 
 func handlePong(conn *websocket.Conn) func(string) error {

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/smartcontractkit/wsrpc/connectivity"
 	"github.com/smartcontractkit/wsrpc/credentials"
 	"github.com/smartcontractkit/wsrpc/logger"
 )
@@ -43,14 +42,14 @@ type ClientTransport interface {
 	// should not be accessed any more.
 	Close()
 
-	// Start starts this transport. 
+	// Start starts this transport.
 	Start()
 }
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(ctx context.Context, lggr logger.Logger, addr string, opts ConnectOptions, onClose func(), getState func() connectivity.State) (ClientTransport, error) {
-	return newWebsocketClient(ctx, lggr, addr, opts, onClose, getState)
+func NewClientTransport(ctx context.Context, lggr logger.Logger, addr string, opts ConnectOptions, onClose func()) (ClientTransport, error) {
+	return newWebsocketClient(ctx, lggr, addr, opts, onClose)
 }
 
 // state of transport.

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/smartcontractkit/wsrpc/connectivity"
 	"github.com/smartcontractkit/wsrpc/credentials"
 	"github.com/smartcontractkit/wsrpc/logger"
 )
@@ -40,13 +41,16 @@ type ClientTransport interface {
 
 	// Close tears down this transport. Once it returns, the transport
 	// should not be accessed any more.
-	Close() error
+	Close()
+
+	// Start starts this transport. 
+	Start()
 }
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(ctx context.Context, lggr logger.Logger, addr string, opts ConnectOptions, onClose func()) (ClientTransport, error) {
-	return newWebsocketClient(ctx, lggr, addr, opts, onClose)
+func NewClientTransport(ctx context.Context, lggr logger.Logger, addr string, opts ConnectOptions, onClose func(), getState func() connectivity.State) (ClientTransport, error) {
+	return newWebsocketClient(ctx, lggr, addr, opts, onClose, getState)
 }
 
 // state of transport.
@@ -82,8 +86,8 @@ type ServerTransport interface {
 
 // NewServerTransport creates a ServerTransport with conn or non-nil error
 // if it fails.
-func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func()) (ServerTransport, error) {
-	return newWebsocketServer(c, config, onClose), nil
+func NewServerTransport(c *websocket.Conn, config *ServerConfig, onClose func()) ServerTransport {
+	return newWebsocketServer(c, config, onClose)
 }
 
 func handlePong(conn *websocket.Conn) func(string) error {

--- a/internal/transport/websocket_client.go
+++ b/internal/transport/websocket_client.go
@@ -24,7 +24,7 @@ type WebsocketClient struct {
 	// Callback function called when the transport is closed
 	onClose func()
 
-	wg *sync.WaitGroup
+	wg sync.WaitGroup
 
 	// Communication channels
 	write chan []byte
@@ -62,7 +62,6 @@ func newWebsocketClient(ctx context.Context, log logger.Logger, addr string, opt
 		writeTimeout: writeTimeout,
 		conn:         conn,
 		onClose:      onClose,
-		wg:           &sync.WaitGroup{},
 		write:        make(chan []byte),
 		read:         make(chan []byte),
 		done:         make(chan struct{}),
@@ -103,7 +102,7 @@ func (c *WebsocketClient) Close() {
 }
 
 // start run readPump in a goroutine and waits on writePump.
-func (c WebsocketClient) Start() {
+func (c *WebsocketClient) Start() {
 	// Set up reader
 	c.wg.Add(1)
 	go c.readPump()

--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -115,10 +115,7 @@ func (s *WebsocketServer) start() {
 // ensures that there is at most one reader on a connection by executing all
 // reads from this goroutine.
 func (s *WebsocketServer) readPump() {
-	defer func() {
-		close(s.closeWritePump)
-		s.conn.Close()
-	}()
+	defer close(s.closeWritePump)
 
 	//nolint:errcheck
 	s.conn.SetReadDeadline(time.Now().Add(pongWait))

--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -23,33 +23,33 @@ type WebsocketServer struct {
 	state transportState
 
 	// Callback function called when the transport is closed
-	onClose func()
+	afterWritePump func()
 
 	// Communication channels
 	write chan []byte
 	read  chan []byte
 
 	// A signal channel called when the reader encounters a websocket close error
-	done chan struct{}
+	closeWritePump chan struct{}
 	// A signal channel called when the transport is closed
-	interrupt chan struct{}
+	closeConn chan struct{}
 }
 
 // newWebsocketServer server upgrades an HTTP connection to a websocket connection.
-func newWebsocketServer(c *websocket.Conn, config *ServerConfig, onClose func()) *WebsocketServer {
+func newWebsocketServer(c *websocket.Conn, config *ServerConfig, afterWritePump func()) *WebsocketServer {
 	writeTimeout := defaultWriteTimeout
 	if config.WriteTimeout != 0 {
 		writeTimeout = config.WriteTimeout
 	}
 
 	s := &WebsocketServer{
-		writeTimeout: writeTimeout,
-		conn:         c,
-		onClose:      onClose,
-		write:        make(chan []byte),
-		read:         make(chan []byte),
-		done:         make(chan struct{}),
-		interrupt:    make(chan struct{}),
+		writeTimeout:   writeTimeout,
+		conn:           c,
+		afterWritePump: afterWritePump,
+		write:          make(chan []byte),
+		read:           make(chan []byte),
+		closeWritePump: make(chan struct{}),
+		closeConn:      make(chan struct{}),
 	}
 
 	go s.start()
@@ -65,9 +65,9 @@ func (s *WebsocketServer) Read() <-chan []byte {
 // Write writes a message the websocket connection.
 func (s *WebsocketServer) Write(ctx context.Context, msg []byte) error {
 	select {
-	case <-s.done:
+	case <-s.closeWritePump:
 		return fmt.Errorf("[wsrpc] could not write message, websocket is closed")
-	case <-s.interrupt:
+	case <-s.closeConn:
 		return fmt.Errorf("[wsrpc] could not write message, transport is closed")
 	case <-ctx.Done():
 		return fmt.Errorf("[wsrpc] could not write message, context is done")
@@ -77,7 +77,7 @@ func (s *WebsocketServer) Write(ctx context.Context, msg []byte) error {
 }
 
 // Close closes the websocket connection and cleans up pump goroutines. Notifies
-// the caller with the onClose callback.
+// the caller with the afterWritePump callback.
 func (s *WebsocketServer) Close() error {
 	s.mu.Lock()
 	// Make sure we only Close once.
@@ -89,8 +89,8 @@ func (s *WebsocketServer) Close() error {
 
 	s.state = closing
 
-	// Close the write channel to stop the go routine
-	close(s.interrupt)
+	// Close the connection and writePump, which causes readPump to close
+	close(s.closeConn)
 
 	s.mu.Unlock()
 
@@ -101,7 +101,7 @@ func (s *WebsocketServer) Close() error {
 func (s *WebsocketServer) start() {
 	defer func() {
 		s.Close()
-		s.onClose()
+		s.afterWritePump()
 	}()
 
 	// Set up reader
@@ -116,7 +116,7 @@ func (s *WebsocketServer) start() {
 // reads from this goroutine.
 func (s *WebsocketServer) readPump() {
 	defer func() {
-		close(s.done)
+		close(s.closeWritePump)
 		s.conn.Close()
 	}()
 
@@ -148,7 +148,7 @@ func (s *WebsocketServer) writePump() {
 
 	for {
 		select {
-		case <-s.done:
+		case <-s.closeWritePump:
 			// When the read detects a websocket closure, it will close the done
 			// channel so we can exit.
 			return
@@ -170,7 +170,7 @@ func (s *WebsocketServer) writePump() {
 
 				return
 			}
-		case <-s.interrupt:
+		case <-s.closeConn:
 			// Cleanly close the connection by sending a close message and then
 			// waiting (with timeout) for the server to close the connection.
 			err := s.conn.WriteMessage(websocket.CloseMessage,
@@ -181,7 +181,7 @@ func (s *WebsocketServer) writePump() {
 			}
 			s.conn.Close()
 			select {
-			case <-s.done:
+			case <-s.closeWritePump:
 			case <-time.After(time.Second):
 			}
 

--- a/intgtest/bi/bi_client_test.go
+++ b/intgtest/bi/bi_client_test.go
@@ -1,4 +1,4 @@
-package intgtest
+package bi_test
 
 import (
 	"context"
@@ -13,19 +13,20 @@ import (
 	"github.com/smartcontractkit/wsrpc"
 	pb "github.com/smartcontractkit/wsrpc/intgtest/internal/rpcs"
 	"github.com/smartcontractkit/wsrpc/peer"
+	"github.com/smartcontractkit/wsrpc/intgtest/utils"
 )
 
 func Test_Bidirectional_ConcurrentCalls(t *testing.T) {
-	keypairs := generateKeys(t)
+	keypairs := utils.GenerateKeys(t)
 	pubKeys := []ed25519.PublicKey{keypairs.Client1.PubKey}
 
 	// Start the server
-	lis, s := setupServer(t,
+	lis, s := utils.SetupServer(t,
 		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server
-	pb.RegisterEchoServer(s, &echoServer{})
+	pb.RegisterEchoServer(s, &utils.EchoServer{})
 
 	// Start serving
 	go s.Serve(lis)
@@ -33,7 +34,7 @@ func Test_Bidirectional_ConcurrentCalls(t *testing.T) {
 	sClient := pb.NewEchoClient(s)
 
 	// Start client
-	conn, err := setupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConn(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 		wsrpc.WithBlock(),
 	)
@@ -42,7 +43,7 @@ func Test_Bidirectional_ConcurrentCalls(t *testing.T) {
 
 	cClient := pb.NewEchoClient(conn)
 	// Register the handlers on the wsrpc client
-	pb.RegisterEchoServer(conn, &echoServer{})
+	pb.RegisterEchoServer(conn, &utils.EchoServer{})
 
 	// Make a client to server call
 	resp, err := cClient.Echo(context.Background(), &pb.EchoRequest{
@@ -71,16 +72,16 @@ func Test_Bidirectional_ConcurrentCalls(t *testing.T) {
 // 2. Client makes a call back to the server in the handler
 // 3. Server returns the response from the client as the echo
 func Test_Bidirectional_MultiplexCalls(t *testing.T) {
-	keypairs := generateKeys(t)
+	keypairs := utils.GenerateKeys(t)
 	pubKeys := []ed25519.PublicKey{keypairs.Client1.PubKey}
 
 	// Start the server
-	lis, s := setupServer(t,
+	lis, s := utils.SetupServer(t,
 		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server
-	pb.RegisterEchoServer(s, &echoServer{})
+	pb.RegisterEchoServer(s, &utils.EchoServer{})
 
 	// Start serving
 	go s.Serve(lis)
@@ -88,7 +89,7 @@ func Test_Bidirectional_MultiplexCalls(t *testing.T) {
 	sClient := pb.NewEchoClient(s)
 
 	// Start client
-	conn, err := setupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConn(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 		wsrpc.WithBlock(),
 	)

--- a/intgtest/bi/bi_client_test.go
+++ b/intgtest/bi/bi_client_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/smartcontractkit/wsrpc"
 	pb "github.com/smartcontractkit/wsrpc/intgtest/internal/rpcs"
-	"github.com/smartcontractkit/wsrpc/peer"
 	"github.com/smartcontractkit/wsrpc/intgtest/utils"
+	"github.com/smartcontractkit/wsrpc/peer"
 )
 
 func Test_Bidirectional_ConcurrentCalls(t *testing.T) {

--- a/intgtest/connection/connection_test.go
+++ b/intgtest/connection/connection_test.go
@@ -187,7 +187,6 @@ func Test_GetConnectedPeerPublicKeys(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(conn.Close)
 
-	// TODO problematic line
 	utils.WaitForReadyConnection(t, conn)
 
 	connectedKeys := s.GetConnectedPeerPublicKeys()

--- a/intgtest/uni/uni_server_client_test.go
+++ b/intgtest/uni/uni_server_client_test.go
@@ -11,15 +11,16 @@ import (
 
 	"github.com/smartcontractkit/wsrpc"
 	pb "github.com/smartcontractkit/wsrpc/intgtest/internal/rpcs"
+	"github.com/smartcontractkit/wsrpc/intgtest/utils"
 	"github.com/smartcontractkit/wsrpc/peer"
 )
 
 func Test_ServerClient_SimpleCall(t *testing.T) {
-	keypairs := generateKeys(t)
+	keypairs := utils.GenerateKeys(t)
 	pubKeys := []ed25519.PublicKey{keypairs.Client1.PubKey}
 
 	// Start the server
-	lis, s := setupServer(t,
+	lis, s := utils.SetupServer(t,
 		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
 	)
 
@@ -30,17 +31,17 @@ func Test_ServerClient_SimpleCall(t *testing.T) {
 	c := pb.NewEchoClient(s)
 
 	// Start client
-	conn, err := setupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConn(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 	)
 	require.NoError(t, err)
 	t.Cleanup(conn.Close)
 
 	// Register the handlers on the wsrpc client
-	pb.RegisterEchoServer(conn, &echoServer{})
+	pb.RegisterEchoServer(conn, &utils.EchoServer{})
 
 	// Wait for the connection to be established
-	waitForReadyConnection(t, conn)
+	utils.WaitForReadyConnection(t, conn)
 
 	ctx := peer.NewCallContext(context.Background(), keypairs.Client1.StaticallySizedPublicKey(t))
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
@@ -53,16 +54,16 @@ func Test_ServerClient_SimpleCall(t *testing.T) {
 }
 
 func Test_ServerClient_ConcurrentCalls(t *testing.T) {
-	keypairs := generateKeys(t)
+	keypairs := utils.GenerateKeys(t)
 	pubKeys := []ed25519.PublicKey{keypairs.Client1.PubKey}
 
-	// Start the server
-	lis, s := setupServer(t,
+	// Start the serverTest_ServerClient_ConcurrentCalls
+	lis, s := utils.SetupServer(t,
 		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server
-	pb.RegisterEchoServer(s, &echoServer{})
+	pb.RegisterEchoServer(s, &utils.EchoServer{})
 	// Create an RPC client for the server
 	c := pb.NewEchoClient(s)
 
@@ -71,7 +72,7 @@ func Test_ServerClient_ConcurrentCalls(t *testing.T) {
 	t.Cleanup(s.Stop)
 
 	// Start client
-	conn, err := setupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConn(t, 500*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 		wsrpc.WithBlock(),
 	)
@@ -79,21 +80,26 @@ func Test_ServerClient_ConcurrentCalls(t *testing.T) {
 	t.Cleanup(conn.Close)
 
 	// Register the handlers on the wsrpc client
-	pb.RegisterEchoServer(conn, &echoServer{})
+	pb.RegisterEchoServer(conn, &utils.EchoServer{})
 
 	respCh := make(chan *pb.EchoResponse)
-	defer close(respCh)
+	doneCh := make(chan []*pb.EchoResponse)
 
 	pk := keypairs.Client1.StaticallySizedPublicKey(t)
-	reqs := []echoReq{
-		{message: &pb.EchoRequest{Body: "call1", DelayMs: 500}, pubKey: &pk},
-		{message: &pb.EchoRequest{Body: "call2"}, timeout: 200 * time.Millisecond, pubKey: &pk},
+	reqs := []utils.EchoReq{
+		{Message: &pb.EchoRequest{Body: "call1", DelayMs: 500}, PubKey: &pk},
+		{Message: &pb.EchoRequest{Body: "call2"}, Timeout: 200000 * time.Millisecond, PubKey: &pk},
 	}
 
-	processEchos(t, c, reqs, respCh)
+	go func() {
+		doneCh <- utils.WaitForResponses(t, respCh, len(reqs))
+	}()
 
-	actual := waitForResponses(t, respCh, 2)
+	utils.ProcessEchos(t, c, reqs, respCh)
 
+	actual := <-doneCh
+
+	assert.Equal(t, len(reqs), len(actual))
 	assert.Equal(t, "call2", actual[0].Body)
 	assert.Equal(t, "call1", actual[1].Body)
 }

--- a/intgtest/uni/uni_server_client_test.go
+++ b/intgtest/uni/uni_server_client_test.go
@@ -88,7 +88,7 @@ func Test_ServerClient_ConcurrentCalls(t *testing.T) {
 	pk := keypairs.Client1.StaticallySizedPublicKey(t)
 	reqs := []utils.EchoReq{
 		{Message: &pb.EchoRequest{Body: "call1", DelayMs: 500}, PubKey: &pk},
-		{Message: &pb.EchoRequest{Body: "call2"}, Timeout: 200000 * time.Millisecond, PubKey: &pk},
+		{Message: &pb.EchoRequest{Body: "call2"}, Timeout: 2000 * time.Millisecond, PubKey: &pk},
 	}
 
 	go func() {

--- a/intgtest/utils/testutils.go
+++ b/intgtest/utils/testutils.go
@@ -78,13 +78,12 @@ func GenerateKeys(t *testing.T) keys {
 // SetupClientConn is a convenience method to setup a client connection for most
 // testing usecases.
 func SetupClientConn(t *testing.T, timeout time.Duration, opts ...wsrpc.DialOption) (*wsrpc.ClientConn, error) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)
 
 	opts = append(opts, wsrpc.WithLogger(logger.Test(t)))
 
-	return wsrpc.DialWithContext(ctx, cancel, targetURI, opts...)
+	return wsrpc.DialWithContext(ctx, targetURI, opts...)
 }
 
 // SetupServer is a convenience method to set up a server for most testing

--- a/server.go
+++ b/server.go
@@ -140,7 +140,7 @@ func (s *Server) wshandler(w http.ResponseWriter, r *http.Request) {
 	done := make(chan struct{})
 
 	config := &transport.ServerConfig{}
-	onClose := func() {
+	afterWritePump := func() {
 		// There is no connection manager when we are shutting down, so
 		// we can ignore removing the connection.
 		s.mu.RLock()
@@ -163,7 +163,7 @@ func (s *Server) wshandler(w http.ResponseWriter, r *http.Request) {
 	s.serveWG.Add(1)
 
 	// Initialize the transport
-	tr := transport.NewServerTransport(conn, config, onClose)
+	tr := transport.NewServerTransport(conn, config, afterWritePump)
 
 	// Register the transport against the public key
 	s.connMgr.registerConnection(pubKey, tr)

--- a/server.go
+++ b/server.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -155,15 +154,13 @@ func (s *Server) wshandler(w http.ResponseWriter, r *http.Request) {
 		close(done)
 	}
 
-
 	s.mu.RLock()
 	if nil == s.connMgr {
 		s.mu.RUnlock()
 		return
 	}
-	time.Sleep(10 * time.Millisecond)
+
 	s.serveWG.Add(1)
-	
 
 	// Initialize the transport
 	tr := transport.NewServerTransport(conn, config, onClose)


### PR DESCRIPTION
Client cleanup logic was all previously async, with different levels of connections relying on contexts, connectivity state, and protocol level errors to close go routines. This meant cleanup of the client was handled async with no coordinated source of truth to wrangle all created go routines as part of normal client operation. 

In this change, I make client cleanup sync. ClientConn's, addrConn's, and WebsocketClients close + teardown functions are all responsible for synchronously closing their own resources and kicking off a shutdown of the lower connectivity levels. This mechanism is coordinated with WaitGroups. Protocol level errors will still cause go routines to close and provide appropriate error logging. 

This change also includes logic to address the original data race issue that kicked off this work: a logical race in Server start and cleanup logic. 