### PR TITLE
feature/2355-audit: addressing audit findings

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,8 +80,11 @@ func DialWithContext(ctxCaller context.Context, target string, opts ...DialOptio
 		methodCalls: map[string]MethodCallHandler{},
 	}
 
-	for _, opt := range opts {
-		opt.apply(&cc.dopts)
+	for i, opt := range opts {
+		err := opt.apply(&cc.dopts)
+		if err != nil {
+			return nil, fmt.Errorf("dial option %d failed: %w", i, err)
+		}
 	}
 
 	// Set the backoff strategy. We may need to consider making this

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -45,7 +45,19 @@ func newFuncDialOption(f func(*dialOptions)) *funcDialOption {
 // level security credentials (e.g., TLS/SSL).
 func WithTransportCreds(privKey ed25519.PrivateKey, serverPubKey ed25519.PublicKey) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		pubs := credentials.NewPublicKeys(serverPubKey)
+		privKey, err := credentials.ValidPrivateKeyFromEd25519(privKey)
+		if err != nil {
+			log.Println(err)
+
+			return
+		}
+
+		pubs, err := credentials.ValidPublicKeysFromEd25519(serverPubKey)
+		if err != nil {
+			log.Println(err)
+
+			return
+		}
 
 		// Generate the TLS config for the client
 		config, err := credentials.NewClientTLSConfig(privKey, pubs)
@@ -73,6 +85,12 @@ func WithBlock() DialOption {
 func WithWriteTimeout(d time.Duration) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.WriteTimeout = d
+	})
+}
+
+func WithReadLimit(size int64) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.copts.ReadLimit = size
 	})
 }
 

--- a/examples/simple/server/main.go
+++ b/examples/simple/server/main.go
@@ -44,7 +44,7 @@ func main() {
 		log.Fatalf("[MAIN] failed to listen: %v", err)
 	}
 	s := wsrpc.NewServer(
-		wsrpc.Creds(privKey, pubKeys),
+		wsrpc.WithCreds(privKey, pubKeys),
 		wsrpc.WithHealthcheck("127.0.0.1:1337"),
 	)
 

--- a/internal/methods/methods.go
+++ b/internal/methods/methods.go
@@ -1,0 +1,68 @@
+package methods
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/wsrpc/credentials"
+	"github.com/smartcontractkit/wsrpc/internal/message"
+)
+
+type MethodCalls struct {
+	MethodCalls map[credentials.StaticSizedPublicKey]*MethodCallsForPublicKey
+}
+
+func NewMethodCalls() *MethodCalls {
+	return &MethodCalls{
+		MethodCalls: make(map[credentials.StaticSizedPublicKey]*MethodCallsForPublicKey),
+	}
+}
+
+func (m *MethodCalls) PutMethodCallForPublicKey(pubKey credentials.StaticSizedPublicKey, id string, ch chan<- *message.Response) {
+	var methodCallsForPubKey *MethodCallsForPublicKey
+	var ok bool
+	if methodCallsForPubKey, ok = m.MethodCalls[pubKey]; !ok {
+		methodCallsForPubKey = NewMethodCallsForPublicKey()
+		m.MethodCalls[pubKey] = methodCallsForPubKey
+	}
+	methodCallsForPubKey.PutMessageResponseChannel(id, ch)
+}
+
+func (m *MethodCalls) GetMessageResponseChannelForPublicKey(pubKey credentials.StaticSizedPublicKey, id string) (chan<- *message.Response, error) {
+	if methodCallsForPubKey, ok := m.MethodCalls[pubKey]; ok {
+		return methodCallsForPubKey.GetMessageResponseChannel(id)
+	}
+
+	return nil, fmt.Errorf("public key not found: %v", pubKey)
+}
+
+func (m *MethodCalls) DeleteMethodCall(pubKey credentials.StaticSizedPublicKey, id string) {
+	if methodCallsForPubKey, ok := m.MethodCalls[pubKey]; ok {
+		methodCallsForPubKey.Delete(id)
+	}
+}
+
+type MethodCallsForPublicKey struct {
+	MethodCallsForPublicKey map[string]chan<- *message.Response
+}
+
+func NewMethodCallsForPublicKey() *MethodCallsForPublicKey {
+	return &MethodCallsForPublicKey{
+		MethodCallsForPublicKey: make(map[string]chan<- *message.Response),
+	}
+}
+
+func (m *MethodCallsForPublicKey) PutMessageResponseChannel(id string, ch chan<- *message.Response) {
+	m.MethodCallsForPublicKey[id] = ch
+}
+
+func (m *MethodCallsForPublicKey) GetMessageResponseChannel(id string) (chan<- *message.Response, error) {
+	call, ok := m.MethodCallsForPublicKey[id]
+	if !ok {
+		return nil, fmt.Errorf("id not found: %v", id)
+	}
+	return call, nil
+}
+
+func (m *MethodCallsForPublicKey) Delete(id string) {
+	delete(m.MethodCallsForPublicKey, id)
+}

--- a/internal/methods/methods_test.go
+++ b/internal/methods/methods_test.go
@@ -1,0 +1,113 @@
+package methods_test
+
+import (
+	"crypto/ed25519"
+
+	"testing"
+
+	"github.com/smartcontractkit/wsrpc/credentials"
+	"github.com/smartcontractkit/wsrpc/internal/message"
+	"github.com/smartcontractkit/wsrpc/internal/methods"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMethodCalls(t *testing.T) {
+	methodCalls := methods.NewMethodCalls()
+	assert.NotNil(t, methodCalls.MethodCalls)
+}
+
+func TestPutMethodCallForPublicKey(t *testing.T) {
+	methodCalls := methods.NewMethodCalls()
+	_, pubKeyBytes, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	var pubKey credentials.StaticSizedPublicKey
+	copy(pubKey[:], pubKeyBytes)
+
+	id := "testID"
+	ch := make(chan *message.Response)
+
+	methodCalls.PutMethodCallForPublicKey(pubKey, id, ch)
+
+	assert.NotNil(t, methodCalls.MethodCalls[pubKey])
+	assert.NotNil(t, methodCalls.MethodCalls[pubKey].MethodCallsForPublicKey[id])
+}
+
+func TestGetMessageResponseChannelForPublicKey(t *testing.T) {
+	methodCalls := methods.NewMethodCalls()
+	_, pubKeyBytes, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	var pubKey credentials.StaticSizedPublicKey
+	copy(pubKey[:], pubKeyBytes)
+
+	id := "testID"
+	ch := make(chan<- *message.Response)
+
+	methodCalls.PutMethodCallForPublicKey(pubKey, id, ch)
+
+	retrievedCh, err := methodCalls.GetMessageResponseChannelForPublicKey(pubKey, id)
+
+	assert.Nil(t, err)
+	assert.Equal(t, ch, retrievedCh)
+}
+
+func TestDeleteMethodCall(t *testing.T) {
+	methodCalls := methods.NewMethodCalls()
+	_, pubKeyBytes, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	var pubKey credentials.StaticSizedPublicKey
+	copy(pubKey[:], pubKeyBytes)
+	id := "testID"
+	ch := make(chan *message.Response)
+
+	methodCalls.PutMethodCallForPublicKey(pubKey, id, ch)
+	methodCalls.DeleteMethodCall(pubKey, id)
+
+	_, err = methodCalls.GetMessageResponseChannelForPublicKey(pubKey, id)
+
+	assert.NotNil(t, err)
+}
+
+func TestNewMethodCallsForPublicKey(t *testing.T) {
+	methodCallsForPubKey := methods.NewMethodCallsForPublicKey()
+	assert.NotNil(t, methodCallsForPubKey.MethodCallsForPublicKey)
+}
+
+func TestPutMessageResponseChannel(t *testing.T) {
+	methodCallsForPubKey := methods.NewMethodCallsForPublicKey()
+	id := "testID"
+	ch := make(chan *message.Response)
+
+	methodCallsForPubKey.PutMessageResponseChannel(id, ch)
+
+	assert.NotNil(t, methodCallsForPubKey.MethodCallsForPublicKey[id])
+}
+
+func TestGetMessageResponseChannel(t *testing.T) {
+	methodCallsForPubKey := methods.NewMethodCallsForPublicKey()
+	id := "testID"
+	ch := make(chan<- *message.Response)
+
+	methodCallsForPubKey.PutMessageResponseChannel(id, ch)
+
+	retrievedCh, err := methodCallsForPubKey.GetMessageResponseChannel(id)
+
+	assert.Nil(t, err)
+	assert.Equal(t, ch, retrievedCh)
+}
+
+func TestDelete(t *testing.T) {
+	methodCallsForPubKey := methods.NewMethodCallsForPublicKey()
+	id := "testID"
+	ch := make(chan *message.Response)
+
+	methodCallsForPubKey.PutMessageResponseChannel(id, ch)
+	methodCallsForPubKey.Delete(id)
+
+	_, err := methodCallsForPubKey.GetMessageResponseChannel(id)
+
+	assert.NotNil(t, err)
+}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1,0 +1,48 @@
+package transport
+
+import (
+	"time"
+)
+
+type mockWebSocketConn struct {
+	readLimit     int64
+	readDeadline  time.Time
+	pongHandler   func(string) error
+	writeDeadline time.Time
+	messageType   int
+	messageData   []byte
+}
+
+func (m *mockWebSocketConn) SetReadLimit(limit int64) {
+	m.readLimit = limit
+}
+
+func (m *mockWebSocketConn) SetReadDeadline(t time.Time) error {
+	m.readDeadline = t
+	return nil
+}
+
+func (m *mockWebSocketConn) SetPongHandler(handler func(string) error) {
+	m.pongHandler = handler
+}
+
+func (m *mockWebSocketConn) SetWriteDeadline(t time.Time) error {
+	m.writeDeadline = t
+	return nil
+}
+
+func (m *mockWebSocketConn) ReadMessage() (messageType int, p []byte, err error) {
+	return m.messageType, m.messageData, nil
+}
+
+func (m *mockWebSocketConn) WriteMessage(messageType int, data []byte) error {
+	return nil
+}
+
+func (m *mockWebSocketConn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	return nil
+}
+
+func (m *mockWebSocketConn) Close() error {
+	return nil
+}

--- a/internal/transport/websocket_client.go
+++ b/internal/transport/websocket_client.go
@@ -41,6 +41,30 @@ type WebsocketClient struct {
 // newWebsocketClient establishes the transport with the required ConnectOptions
 // and returns it to the caller.
 func newWebsocketClient(ctx context.Context, log logger.Logger, addr string, opts ConnectOptions, afterWritePump func()) (*WebsocketClient, error) {
+	d := websocket.Dialer{
+		TLSClientConfig:  opts.TransportCredentials.Config,
+		HandshakeTimeout: 45 * time.Second,
+	}
+
+	url := fmt.Sprintf("wss://%s", addr)
+
+	var conn WebSocketConn
+	var err error
+	conn, _, err = d.DialContext(ctx, url, http.Header{})
+
+	if err != nil {
+		return nil, fmt.Errorf("[wsrpc] error while dialing %w", err)
+	}
+
+	c := newWebsocketClientConfig(ctx, log, addr, opts, afterWritePump, conn)
+
+	// Start go routines to establish the read/write channels
+	c.Start()
+
+	return c, nil
+}
+
+func newWebsocketClientConfig(ctx context.Context, log logger.Logger, addr string, opts ConnectOptions, afterWritePump func(), conn WebSocketConn) *WebsocketClient {
 	writeTimeout := defaultWriteTimeout
 	if opts.WriteTimeout != 0 {
 		writeTimeout = opts.WriteTimeout
@@ -49,17 +73,6 @@ func newWebsocketClient(ctx context.Context, log logger.Logger, addr string, opt
 	readLimit := defaultReadLimit
 	if opts.ReadLimit != 0 {
 		readLimit = opts.ReadLimit
-	}
-
-	d := websocket.Dialer{
-		TLSClientConfig:  opts.TransportCredentials.Config,
-		HandshakeTimeout: 45 * time.Second,
-	}
-
-	url := fmt.Sprintf("wss://%s", addr)
-	conn, _, err := d.DialContext(ctx, url, http.Header{})
-	if err != nil {
-		return nil, fmt.Errorf("[wsrpc] error while dialing %w", err)
 	}
 
 	conn.SetReadLimit(readLimit)
@@ -76,10 +89,7 @@ func newWebsocketClient(ctx context.Context, log logger.Logger, addr string, opt
 		log:            log,
 	}
 
-	// Start go routines to establish the read/write channels
-	c.Start()
-
-	return c, nil
+	return c
 }
 
 // Read returns a channel which provides the messages as they are read.

--- a/internal/transport/websocket_client.go
+++ b/internal/transport/websocket_client.go
@@ -19,7 +19,7 @@ type WebsocketClient struct {
 	writeTimeout time.Duration
 
 	// Underlying communication channel
-	conn *websocket.Conn
+	conn WebSocketConn
 
 	// Callback function called when the transport is closed
 	afterWritePump func()
@@ -46,6 +46,11 @@ func newWebsocketClient(ctx context.Context, log logger.Logger, addr string, opt
 		writeTimeout = opts.WriteTimeout
 	}
 
+	readLimit := defaultReadLimit
+	if opts.ReadLimit != 0 {
+		readLimit = opts.ReadLimit
+	}
+
 	d := websocket.Dialer{
 		TLSClientConfig:  opts.TransportCredentials.Config,
 		HandshakeTimeout: 45 * time.Second,
@@ -56,6 +61,8 @@ func newWebsocketClient(ctx context.Context, log logger.Logger, addr string, opt
 	if err != nil {
 		return nil, fmt.Errorf("[wsrpc] error while dialing %w", err)
 	}
+
+	conn.SetReadLimit(readLimit)
 
 	c := &WebsocketClient{
 		ctx:            ctx,

--- a/internal/transport/websocket_client_test.go
+++ b/internal/transport/websocket_client_test.go
@@ -1,1 +1,55 @@
 package transport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/wsrpc/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewWebsocketClientConfig(t *testing.T) {
+	ctx := context.Background()
+	afterWritePump := func() {}
+	mockLogger := logger.DefaultLogger
+	mockConn := &mockWebSocketConn{}
+
+	tests := []struct {
+		name            string
+		opts            ConnectOptions
+		expectedTimeout time.Duration
+		expectedLimit   int64
+	}{
+		{
+			name:            "Default values",
+			opts:            ConnectOptions{},
+			expectedTimeout: defaultWriteTimeout,
+			expectedLimit:   int64(defaultReadLimit),
+		},
+		{
+			name: "Custom WriteTimeout",
+			opts: ConnectOptions{
+				WriteTimeout: 5 * time.Second,
+			},
+			expectedTimeout: 5 * time.Second,
+			expectedLimit:   int64(defaultReadLimit),
+		},
+		{
+			name: "Custom ReadLimit",
+			opts: ConnectOptions{
+				ReadLimit: 2048,
+			},
+			expectedTimeout: defaultWriteTimeout,
+			expectedLimit:   2048,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newWebsocketClientConfig(ctx, mockLogger, "addr", tt.opts, afterWritePump, mockConn)
+			assert.Equal(t, tt.expectedTimeout, client.writeTimeout)
+			assert.Equal(t, tt.expectedLimit, mockConn.readLimit)
+		})
+	}
+}

--- a/internal/transport/websocket_server.go
+++ b/internal/transport/websocket_server.go
@@ -16,9 +16,6 @@ type WebsocketServer struct {
 	// config
 	writeTimeout time.Duration
 
-	// config: max bytes in a message request
-	readLimit int64
-
 	// Underlying communication channel
 	conn WebSocketConn
 
@@ -60,7 +57,6 @@ func newWebsocketServerWithConfig(c WebSocketConn, config *ServerConfig, afterWr
 
 	s := &WebsocketServer{
 		writeTimeout:   writeTimeout,
-		readLimit:      readLimit,
 		conn:           c,
 		afterWritePump: afterWritePump,
 		write:          make(chan []byte),

--- a/internal/transport/websocket_server_test.go
+++ b/internal/transport/websocket_server_test.go
@@ -1,1 +1,94 @@
 package transport
+
+import (
+	"testing"
+	"time"
+)
+
+type mockWebSocketConn struct {
+	readLimit     int64
+	readDeadline  time.Time
+	pongHandler   func(string) error
+	writeDeadline time.Time
+	messageType   int
+	messageData   []byte
+}
+
+func (m *mockWebSocketConn) SetReadLimit(limit int64) {
+	m.readLimit = limit
+}
+
+func (m *mockWebSocketConn) SetReadDeadline(t time.Time) error {
+	m.readDeadline = t
+	return nil
+}
+
+func (m *mockWebSocketConn) SetPongHandler(handler func(string) error) {
+	m.pongHandler = handler
+}
+
+func (m *mockWebSocketConn) SetWriteDeadline(t time.Time) error {
+	m.writeDeadline = t
+	return nil
+}
+
+func (m *mockWebSocketConn) ReadMessage() (messageType int, p []byte, err error) {
+	return m.messageType, m.messageData, nil
+}
+
+func (m *mockWebSocketConn) WriteMessage(messageType int, data []byte) error {
+	return nil
+}
+
+func (m *mockWebSocketConn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	return nil
+}
+
+func (m *mockWebSocketConn) Close() error {
+	return nil
+}
+
+func TestNewWebsocketServerWithConfig(t *testing.T) {
+	mockConn := &mockWebSocketConn{}
+
+	tests := []struct {
+		name        string
+		config      *ServerConfig
+		wantTimeout time.Duration
+		wantLimit   int64
+	}{
+		{
+			name:        "Defaults",
+			config:      &ServerConfig{},
+			wantTimeout: defaultWriteTimeout,
+			wantLimit:   defaultReadLimit,
+		},
+		{
+			name: "Custom",
+			config: &ServerConfig{
+				WriteTimeout: 2 * time.Second,
+				ReadLimit:    2048,
+			},
+			wantTimeout: 2 * time.Second,
+			wantLimit:   2048,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newWebsocketServerWithConfig(mockConn, tt.config, nil)
+
+			if server.writeTimeout != tt.wantTimeout {
+				t.Errorf("newWebsocketServerWithConfig().writeTimeout = %v, want %v", server.writeTimeout, tt.wantTimeout)
+			}
+
+			if server.readLimit != tt.wantLimit {
+				t.Errorf("newWebsocketServerWithConfig().readLimit = %v, want %v", server.readLimit, tt.wantLimit)
+			}
+
+			if mockConn.readLimit != tt.wantLimit {
+				t.Errorf("mockConn.readLimit = %v, want %v", mockConn.readLimit, tt.wantLimit)
+			}
+		})
+	}
+}

--- a/intgtest/bi/bi_client_test.go
+++ b/intgtest/bi/bi_client_test.go
@@ -22,7 +22,7 @@ func Test_Bidirectional_ConcurrentCalls(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server
@@ -77,7 +77,7 @@ func Test_Bidirectional_MultiplexCalls(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server

--- a/intgtest/bi/bi_client_test.go
+++ b/intgtest/bi/bi_client_test.go
@@ -34,7 +34,7 @@ func Test_Bidirectional_ConcurrentCalls(t *testing.T) {
 	sClient := pb.NewEchoClient(s)
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 		wsrpc.WithBlock(),
 	)
@@ -89,7 +89,7 @@ func Test_Bidirectional_MultiplexCalls(t *testing.T) {
 	sClient := pb.NewEchoClient(s)
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 		wsrpc.WithBlock(),
 	)

--- a/intgtest/connection/connection_test.go
+++ b/intgtest/connection/connection_test.go
@@ -56,7 +56,7 @@ func Test_AutomatedConnectionRetry(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server
@@ -97,7 +97,7 @@ func Test_BlockingDial(t *testing.T) {
 	// Start the server in a goroutine. We wait to start up the server so we can
 	// test the blocking mechanism.
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	pb.RegisterEchoServer(s, &utils.EchoServer{})
@@ -134,7 +134,7 @@ func Test_InvalidCredentials(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server
@@ -157,7 +157,8 @@ func Test_InvalidCredentials(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// Update the servers allowed list of public keys to include the client's
-	s.UpdatePublicKeys([]ed25519.PublicKey{keypairs.Client1.PubKey})
+	err = s.UpdatePublicKeys(keypairs.Client1.PubKey)
+	require.NoError(t, err)
 
 	utils.WaitForReadyConnection(t, conn)
 }
@@ -168,7 +169,7 @@ func Test_GetConnectedPeerPublicKeys(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server
@@ -202,7 +203,7 @@ func Test_GetNotificationChan(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server

--- a/intgtest/connection/connection_test.go
+++ b/intgtest/connection/connection_test.go
@@ -21,7 +21,7 @@ func Test_ServerNotRunning(t *testing.T) {
 	keypairs := utils.GenerateKeys(t)
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 	)
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func Test_AutomatedConnectionRetry(t *testing.T) {
 	pubKeys := []ed25519.PublicKey{keypairs.Client1.PubKey}
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 	)
 	require.NoError(t, err)
@@ -85,7 +85,7 @@ func Test_BlockingDial(t *testing.T) {
 	unblocked := make(chan *wsrpc.ClientConn)
 
 	go func() {
-		conn, err := utils.SetupClientConn(t, 5*time.Second,
+		conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 			wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 			wsrpc.WithBlock(),
 		)
@@ -120,7 +120,7 @@ func Test_BlockingDialTimeout(t *testing.T) {
 	keypairs := utils.GenerateKeys(t)
 
 	// Start client
-	_, err := utils.SetupClientConn(t, 50*time.Millisecond,
+	_, err := utils.SetupClientConnWithOptsAndTimeout(t, 50*time.Millisecond,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 		wsrpc.WithBlock(),
 	)
@@ -145,7 +145,7 @@ func Test_InvalidCredentials(t *testing.T) {
 	t.Cleanup(s.Stop)
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 	)
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func Test_GetConnectedPeerPublicKeys(t *testing.T) {
 	require.Empty(t, s.GetConnectedPeerPublicKeys())
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 	)
 	require.NoError(t, err)
@@ -216,7 +216,7 @@ func Test_GetNotificationChan(t *testing.T) {
 	notifyChan := s.GetConnectionNotifyChan()
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 100*time.Millisecond,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 100*time.Millisecond,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 	)
 	require.NoError(t, err)

--- a/intgtest/uni/uni_client_server_test.go
+++ b/intgtest/uni/uni_client_server_test.go
@@ -31,7 +31,7 @@ func Test_ClientServer_SimpleCall(t *testing.T) {
 	t.Cleanup(s.Stop)
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 	)
 	require.NoError(t, err)
@@ -67,7 +67,7 @@ func Test_ClientServer_ConcurrentCalls(t *testing.T) {
 	t.Cleanup(s.Stop)
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 		wsrpc.WithBlock(),
 	)

--- a/intgtest/uni/uni_client_server_test.go
+++ b/intgtest/uni/uni_client_server_test.go
@@ -20,7 +20,7 @@ func Test_ClientServer_SimpleCall(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server
@@ -56,7 +56,7 @@ func Test_ClientServer_ConcurrentCalls(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the echo server implementation with the wsrpc server

--- a/intgtest/uni/uni_server_client_test.go
+++ b/intgtest/uni/uni_server_client_test.go
@@ -31,7 +31,7 @@ func Test_ServerClient_SimpleCall(t *testing.T) {
 	c := pb.NewEchoClient(s)
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 5*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 5*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 	)
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func Test_ServerClient_ConcurrentCalls(t *testing.T) {
 	t.Cleanup(s.Stop)
 
 	// Start client
-	conn, err := utils.SetupClientConn(t, 500*time.Second,
+	conn, err := utils.SetupClientConnWithOptsAndTimeout(t, 500*time.Second,
 		wsrpc.WithTransportCreds(keypairs.Client1.PrivKey, keypairs.Server.PubKey),
 		wsrpc.WithBlock(),
 	)

--- a/intgtest/uni/uni_server_client_test.go
+++ b/intgtest/uni/uni_server_client_test.go
@@ -21,7 +21,7 @@ func Test_ServerClient_SimpleCall(t *testing.T) {
 
 	// Start the server
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Start serving
@@ -59,7 +59,7 @@ func Test_ServerClient_ConcurrentCalls(t *testing.T) {
 
 	// Start the serverTest_ServerClient_ConcurrentCalls
 	lis, s := utils.SetupServer(t,
-		wsrpc.Creds(keypairs.Server.PrivKey, pubKeys),
+		wsrpc.WithCreds(keypairs.Server.PrivKey, pubKeys),
 	)
 
 	// Register the ping server implementation with the wsrpc server

--- a/intgtest/utils/testutils.go
+++ b/intgtest/utils/testutils.go
@@ -75,9 +75,9 @@ func GenerateKeys(t *testing.T) keys {
 	}
 }
 
-// SetupClientConn is a convenience method to setup a client connection for most
+// SetupClientConnWithOptsAndTimeout is a convenience method to setup a client connection for most
 // testing usecases.
-func SetupClientConn(t *testing.T, timeout time.Duration, opts ...wsrpc.DialOption) (*wsrpc.ClientConn, error) {
+func SetupClientConnWithOptsAndTimeout(t *testing.T, timeout time.Duration, opts ...wsrpc.DialOption) (*wsrpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)
 

--- a/server.go
+++ b/server.go
@@ -290,12 +290,12 @@ func (s *Server) handleMessageResponse(pubKey credentials.StaticSizedPublicKey, 
 func (s *Server) validateMessageRequest(r *message.Request) error {
 	methodName := r.GetMethod()
 	if _, ok := s.service.methods[methodName]; !ok {
-		return fmt.Errorf("invalid method: %v", methodName)
+		return fmt.Errorf("unrecognized method: %v", methodName)
 	}
 
 	callId := r.GetCallId()
 	if id, err := uuid.Parse(callId); err != nil || id.Version() != 4 {
-		return fmt.Errorf("invalid callId: %v", callId)
+		return fmt.Errorf("invalid callId %s: %w", callId, err)
 	}
 
 	return nil

--- a/server.go
+++ b/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/smartcontractkit/wsrpc/credentials"
 	"github.com/smartcontractkit/wsrpc/internal/message"
+	"github.com/smartcontractkit/wsrpc/internal/methods"
 	"github.com/smartcontractkit/wsrpc/internal/transport"
 	"github.com/smartcontractkit/wsrpc/internal/wsrpcsync"
 	"github.com/smartcontractkit/wsrpc/peer"
@@ -41,7 +42,7 @@ type Server struct {
 
 	// Contains all pending method call ids and the channel to respond to when
 	// a result is received
-	methodCalls map[string]chan<- *message.Response
+	methodCalls *methods.MethodCalls
 
 	// Signals a quit event when the server wants to quit
 	quit *wsrpcsync.Event
@@ -65,7 +66,7 @@ func NewServer(opt ...ServerOption) *Server {
 			WriteBufferSize: opts.writeBufferSize,
 		},
 		connMgr:     newConnectionsManager(),
-		methodCalls: map[string]chan<- *message.Response{},
+		methodCalls: methods.NewMethodCalls(),
 		quit:        wsrpcsync.NewEvent(),
 		done:        wsrpcsync.NewEvent(),
 		serveWG:     sync.WaitGroup{},
@@ -140,6 +141,9 @@ func (s *Server) wshandler(w http.ResponseWriter, r *http.Request) {
 	done := make(chan struct{})
 
 	config := &transport.ServerConfig{}
+	config.ReadLimit = s.opts.wsReadLimit
+	config.WriteTimeout = s.opts.wsTimeout
+
 	afterWritePump := func() {
 		// There is no connection manager when we are shutting down, so
 		// we can ignore removing the connection.
@@ -221,7 +225,7 @@ func (s *Server) handleRead(pubKey credentials.StaticSizedPublicKey, done <-chan
 			case *message.Message_Request:
 				go s.handleMessageRequest(pubKey, ex.Request)
 			case *message.Message_Response:
-				go s.handleMessageResponse(ex.Response)
+				go s.handleMessageResponse(pubKey, ex.Response)
 			default:
 				log.Println("Invalid message type")
 			}
@@ -235,45 +239,66 @@ func (s *Server) handleRead(pubKey credentials.StaticSizedPublicKey, done <-chan
 // the handler. The connection client's public key is injected into the context,
 // so the handler is able to identify the caller.
 func (s *Server) handleMessageRequest(pubKey credentials.StaticSizedPublicKey, r *message.Request) {
+	if err := s.validateMessageRequest(r); err != nil {
+		log.Printf("error validating request: %s", err)
+		return
+	}
+
 	methodName := r.GetMethod()
-	if md, ok := s.service.methods[methodName]; ok {
-		// Create a decoder function to unmarshal the message
-		dec := func(v interface{}) error {
-			return UnmarshalProtoMessage(r.GetPayload(), v)
-		}
+	md := s.service.methods[methodName]
+	// Create a decoder function to unmarshal the message
+	dec := func(v interface{}) error {
+		return UnmarshalProtoMessage(r.GetPayload(), v)
+	}
 
-		// Inject the peer's public key into the context so the handler can use it
-		ctx := peer.NewContext(context.Background(), &peer.Peer{PublicKey: pubKey})
-		v, herr := md.Handler(s.service.serviceImpl, ctx, dec)
+	// Inject the peer's public key into the context so the handler can use it
+	ctx := peer.NewContext(context.Background(), &peer.Peer{PublicKey: pubKey})
+	v, herr := md.Handler(s.service.serviceImpl, ctx, dec)
 
-		msg, err := message.NewResponse(r.GetCallId(), v, herr)
-		if err != nil {
-			return
-		}
+	msg, err := message.NewResponse(r.GetCallId(), v, herr)
+	if err != nil {
+		return
+	}
 
-		replyMsg, err := MarshalProtoMessage(msg)
-		if err != nil {
-			return
-		}
+	replyMsg, err := MarshalProtoMessage(msg)
+	if err != nil {
+		return
+	}
 
-		if err := s.sendMsg(ctx, pubKey, replyMsg); err != nil {
-			log.Printf("error sending message: %s", err)
-		}
+	if err := s.sendMsg(ctx, pubKey, replyMsg); err != nil {
+		log.Printf("error sending message: %s", err)
 	}
 }
 
 // handleMessageResponse finds the call which matches the method call id of the
 // response and sends the payload to the call channel.
-func (s *Server) handleMessageResponse(r *message.Response) {
+func (s *Server) handleMessageResponse(pubKey credentials.StaticSizedPublicKey, r *message.Response) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	callID := r.GetCallId()
-	if call, ok := s.methodCalls[callID]; ok {
-		call <- r
-
-		s.removeMethodCall(callID) // Delete the call now that we have completed the request/response cycle
+	call, err := s.methodCalls.GetMessageResponseChannelForPublicKey(pubKey, callID)
+	if err != nil {
+		log.Printf("error handling message response: %s", err)
+		return
 	}
+
+	call <- r
+	s.removeMethodCall(pubKey, callID) // Delete the call now that we have completed the request/response cycle
+}
+
+func (s *Server) validateMessageRequest(r *message.Request) error {
+	methodName := r.GetMethod()
+	if _, ok := s.service.methods[methodName]; !ok {
+		return fmt.Errorf("invalid method: %v", methodName)
+	}
+
+	callId := r.GetCallId()
+	if id, err := uuid.Parse(callId); err != nil || id.Version() != 4 {
+		return fmt.Errorf("invalid callId: %v", callId)
+	}
+
+	return nil
 }
 
 // RegisterService registers a service and its implementation to the wsrpc
@@ -311,16 +336,16 @@ func (s *Server) Invoke(ctx context.Context, method string, args interface{}, re
 		return err
 	}
 
-	s.mu.Lock()
-	wait := s.registerMethodCall(callID)
-	s.mu.Unlock()
-
 	// Extract the public key from context
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return errors.New("could not extract public key")
 	}
 	pubKey := p.PublicKey
+
+	s.mu.Lock()
+	wait := s.registerMethodCall(pubKey, callID)
+	s.mu.Unlock()
 
 	if err = s.sendMsg(ctx, pubKey, req); err != nil {
 		return err
@@ -341,7 +366,7 @@ func (s *Server) Invoke(ctx context.Context, method string, args interface{}, re
 	case <-ctx.Done():
 		// Remove the call since we have timeout
 		s.mu.Lock()
-		s.removeMethodCall(callID)
+		s.removeMethodCall(pubKey, callID)
 		s.mu.Unlock()
 
 		return fmt.Errorf("call timeout: %w", ctx.Err())
@@ -352,12 +377,18 @@ func (s *Server) Invoke(ctx context.Context, method string, args interface{}, re
 
 // UpdatePublicKeys updates the list of allowable public keys in the TLS config
 // and drops the connections which match the deleted keys.
-func (s *Server) UpdatePublicKeys(pubKeys []ed25519.PublicKey) {
+func (s *Server) UpdatePublicKeys(ed25519PubKeys ...ed25519.PublicKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	pubKeys, err := credentials.ValidPublicKeysFromEd25519(ed25519PubKeys...)
+	if err != nil {
+		return fmt.Errorf("invalid public keys: %s", err)
+	}
+
 	s.opts.creds.PublicKeys.Replace(pubKeys) //credentials.NewPublicKeys(pubKeys...)
 	s.removeConnectionsToDeletedKeys(pubKeys)
+	return nil
 }
 
 // GetConnectionNotifyChan gets the connection notification channel.
@@ -402,10 +433,10 @@ func (s *Server) Stop() {
 
 // When the list of allowable certs are updated, we need to refresh the existing
 // connections as well and shutdown any client connections no longer allowed.
-func (s *Server) removeConnectionsToDeletedKeys(pubKeys []ed25519.PublicKey) {
+func (s *Server) removeConnectionsToDeletedKeys(pubKeys *credentials.PublicKeys) {
 	pubKeysMap := make(map[credentials.StaticSizedPublicKey]bool)
 
-	for _, pk := range pubKeys {
+	for _, pk := range pubKeys.Keys() {
 		pubKey, err := credentials.ToStaticallySizedPublicKey(pk)
 		if err != nil {
 			log.Print("[Server] error reading keys while removing connections: ", err)
@@ -446,9 +477,9 @@ func (s *Server) ensureSingleClientConnection(cert *x509.Certificate) ([ed25519.
 // registerMethodCall registers a method call to the method call map.
 //
 // This requires a lock on cc.mu.
-func (s *Server) registerMethodCall(id string) <-chan *message.Response {
+func (s *Server) registerMethodCall(pubKey credentials.StaticSizedPublicKey, id string) <-chan *message.Response {
 	wait := make(chan *message.Response)
-	s.methodCalls[id] = wait
+	s.methodCalls.PutMethodCallForPublicKey(pubKey, id, wait)
 
 	return wait
 }
@@ -456,8 +487,8 @@ func (s *Server) registerMethodCall(id string) <-chan *message.Response {
 // removeMethodCall deregisters a method call to the method call map.
 //
 // This requires a lock on cc.mu.
-func (s *Server) removeMethodCall(id string) {
-	delete(s.methodCalls, id)
+func (s *Server) removeMethodCall(pubKey credentials.StaticSizedPublicKey, id string) {
+	s.methodCalls.DeleteMethodCall(pubKey, id)
 }
 
 // connectionsManager manages the active clients connections.


### PR DESCRIPTION
Builds on #42

* RPC methods are now associated with a public key and call id
* Fixes potential for unbounded `callId` length in proto buf messages
* Adds constant time public key comparison
* Adds validation of public and private key sizes
* Validates `callId`s are UUIDv4 formatted

SonarQube has a broken coverage calculation, but fixing that is out of scope for this PR. 