### PR TITLE
move the failure to connect message until after shutdown state check

### DIFF
--- a/client.go
+++ b/client.go
@@ -555,13 +555,13 @@ func (ac *addrConn) resetTransport() {
 
 		ac.mu.Unlock()
 		if err != nil {
-			ac.dopts.logger.Errorf("failed to connect to server at %s, got: %v", addr, err)
 			// After connection failure, the addrConn enters TRANSIENT_FAILURE.
 			ac.mu.Lock()
 			if ac.state == connectivity.Shutdown {
 				ac.mu.Unlock()
 				return
 			}
+			ac.dopts.logger.Errorf("failed to connect to server at %s, got: %v", addr, err)
 			ac.updateConnectivityState(connectivity.TransientFailure)
 			ac.mu.Unlock()
 


### PR DESCRIPTION
Reasoning behind the change:

From BCF-3112, we see this panic in the logs:

panic: Log in goroutine after TestTelemetryIngressClient_Send_HappyPath has completed: 2024-03-

The wsrpc client runs 'resetTransport' in a goroutine, the routine does check that the state of the client in not in shutdown  before attempting to reconnect, however, whilst attempting to connect the state can be changed to shutdown if the client is 'closed' (ie by,  in this case, the test exiting).  Thus, if the createTransport call errors (as is likely in the test shutdown scenario) the client will attempt to log the connection error.  The fix is straightforward and no risk -> move the log until after the existing state check, not logging the error in the case where the client is in 'shutdown' state seems sensible.





