### PR TITLE
adding nil transport check in the case the state is not ready

### DIFF
--- a/client.go
+++ b/client.go
@@ -417,6 +417,11 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{
 	}
 	cc.addrConn.mu.RLock()
 	tr = cc.addrConn.transport
+	if tr == nil {
+		defer cc.mu.RUnlock()
+		// State is reconnecting
+		return errors.New("connection is not ready")
+	}
 	cc.addrConn.mu.RUnlock()
 	cc.mu.RUnlock()
 


### PR DESCRIPTION
Addresses the following observed panic

```
024-07-10T10:09:41.828Z [WARN]  Could not send telemetry: call timeout: context deadline exceeded synchronization/telemetry_ingress_batch_worker.go:86 logger=TelemetryManager.TelemetryIngressBatchWorker version=2.12.1-automation@7fb8365 
2024-07-10T10:09:41.828Z [ERROR] Write error: write tcp 172.17.0.49:44814->54.188.89.108:8080: i/o timeout transport/websocket_client.go:186 logger=TelemetryManager.TelemetryIngressBatchClient.EVM.100 stacktrace=github.com/smartcontractkit/wsrpc/internal/transport.(*WebsocketClient).writePump
	/go/pkg/mod/github.com/smartcontractkit/wsrpc@v0.8.1/internal/transport/websocket_client.go:186 version=2.12.1-automation@7fb8365 
2024-07-10T10:09:41.828Z [INFO]  Reconnecting to server...                          wsrpc@v0.8.1/client.go:605       logger=TelemetryManager.TelemetryIngressBatchClient.EVM.100 version=2.12.1-automation@7fb8365 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1d9c232]

goroutine 917 [running]:
github.com/smartcontractkit/wsrpc.(*ClientConn).Invoke(0xc0009da900, {0x4152108, 0xc0008ec150}, {0x33ddab6, 0xa}, {0x311de80, 0xc0008ec0e0}, {0x2fee620, 0xc018848740})
	/go/pkg/mod/github.com/smartcontractkit/wsrpc@v0.8.1/client.go:423 +0x532
github.com/smartcontractkit/chainlink/v2/core/services/synchronization/telem.(*telemClient).TelemBatch(0xc0003d4b40, {0x4152108, 0xc0008ec150}, 0xc017e5a370?)
	/chainlink/core/services/synchronization/telem/telem_wsrpc.pb.go:39 +0x7b
github.com/smartcontractkit/chainlink/v2/core/services/synchronization.(*telemetryIngressBatchWorker).Start.func1()
	/chainlink/core/services/synchronization/telemetry_ingress_batch_worker.go:82 +0x154
created by github.com/smartcontractkit/chainlink/v2/core/services/synchronization.(*telemetryIngressBatchWorker).Start in goroutine 843
	/chainlink/core/services/synchronization/telemetry_ingress_batch_worker.go:69 +0x89
```