### PR TITLE
adding nil check before tr.Write call

### DIFF
--- a/client.go
+++ b/client.go
@@ -416,6 +416,11 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{
 	cc.addrConn.mu.RUnlock()
 	cc.mu.RUnlock()
 
+	if tr == nil {
+		// addrConn is reconnecting
+		return errors.New("transport is unavailable for writing")
+	}
+
 	if err := tr.Write(ctx, reqB); err != nil {
 		return err
 	}


### PR DESCRIPTION
Some panics were observed on the call to tr.Write. It's possible that in a reconnection loop a waiting Invoke call could grab the read mutex while the transport is still nil

The tradeoff with this approach (vs blocking all invoke calls until reconnecting is complete) is that any in-flight Invoke call that hits this edge case will error out. Consumers may need to adapt accordingly under poor network conditions. I chose this b/c i believe ultimately it will be safer wrt lock contention. 