### PR TITLE
checking addrConn is nil before proceeding with Invoke

### DIFF
--- a/client.go
+++ b/client.go
@@ -372,6 +372,9 @@ func (cc *ClientConn) Close() error {
 func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{}, reply interface{}) error {
 	// Ensure the connection state is ready
 	cc.mu.RLock()
+	if cc.addrConn == nil {
+		return errors.New("client connection is not ready to proceed with Invoke")
+	}
 	cc.addrConn.mu.RLock()
 	state := cc.addrConn.state
 	cc.addrConn.mu.RUnlock()


### PR DESCRIPTION
addrConn is set to nil when the Client is closed. Depending on consumer usage of wsrpc, it's possible that an invoke call is kicked off after it is set to nil and addrConn is tearing down lower levels