### PR TITLE
revert changes from v0.8.3 & v0.8.4

### DIFF
--- a/client.go
+++ b/client.go
@@ -372,9 +372,6 @@ func (cc *ClientConn) Close() error {
 func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{}, reply interface{}) error {
 	// Ensure the connection state is ready
 	cc.mu.RLock()
-	if cc.addrConn == nil {
-		return errors.New("client connection is not ready to proceed with Invoke")
-	}
 	cc.addrConn.mu.RLock()
 	state := cc.addrConn.state
 	cc.addrConn.mu.RUnlock()

--- a/client.go
+++ b/client.go
@@ -416,11 +416,6 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{
 	cc.addrConn.mu.RUnlock()
 	cc.mu.RUnlock()
 
-	if tr == nil {
-		// addrConn is reconnecting
-		return errors.New("transport is unavailable for writing")
-	}
-
 	if err := tr.Write(ctx, reqB); err != nil {
 		return err
 	}


### PR DESCRIPTION
We are running v0.8.2 in core, and unable to upgrade due to changes introduced in v0.8.3 and v0.8.4. This PR reverts those changes, to make way for a new release that we will be able to upgrade to.
```
$ git revert -m 1 6f457b07a5ad0aee7e139a7f5af7113c1b7347c7
$ git revert -m 1 e8034e3af381a3543c88431542a9ba2e0c342f24
```