### PR TITLE
safeguard transport transient state

### DIFF
--- a/client.go
+++ b/client.go
@@ -416,6 +416,10 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{
 	cc.addrConn.mu.RUnlock()
 	cc.mu.RUnlock()
 
+	if tr == nil {
+		return errors.New("transport not ready")
+	}
+
 	if err := tr.Write(ctx, reqB); err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -417,7 +417,7 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args interface{
 	cc.mu.RUnlock()
 
 	if tr == nil {
-		return errors.New("transport not ready")
+		return errors.New("wsrpc: transport not ready")
 	}
 
 	if err := tr.Write(ctx, reqB); err != nil {


### PR DESCRIPTION
Prevents panics in connection state management.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x2a0e66b]
goroutine 19759 [running]:
github.com/smartcontractkit/wsrpc.(*ClientConn).Invoke(0xc0008a78c0, {0x7679750, 0xc01fe46460}, {0x66d2759, 0xa}, {0x639b2a0, 0xc01fe463f0}, {0x623e1c0, 0xc023b70040})
/go/pkg/mod/github.com/smartcontractkit/wsrpc@v0.8.5-0.20250318131857-4568a0f8d12d/client.go:419 +0x50b
github.com/smartcontractkit/chainlink/v2/core/services/synchronization/telem.(*telemClient).TelemBatch(0xc001589db0, {0x7679750, 0xc01fe46460}, 0xc01fe463f0)
	/chainlink/core/services/synchronization/telem/telem_wsrpc.pb.go:38 +0x78
github.com/smartcontractkit/chainlink/v2/core/services/synchronization.(*telemetryIngressBatchWorker).Send(0xc005069170, {0x7679718, 0xc001947ea0})
	/chainlink/core/services/synchronization/telemetry_ingress_batch_worker.go:68 +0x9e
github.com/smartcontractkit/chainlink/v2/core/services/synchronization.(*telemetryIngressBatchClient).findOrCreateWorker.(*Engine).GoTick.func2({0x7679718, 0xc001947ea0})
	/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.7.1-0.20250429205337-7ee5f91ed065/pkg/services/service.go:96 +0x8a
github.com/smartcontractkit/chainlink-common/pkg/services.(*Engine).Go.func1()
	/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.7.1-0.20250429205337-7ee5f91ed065/pkg/services/service.go:74 +0x6c
created by github.com/smartcontractkit/chainlink-common/pkg/services.(*Engine).Go in goroutine 6187
	/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.7.1-0.20250429205337-7ee5f91ed065/pkg/services/service.go:70 +0x76
```